### PR TITLE
feat: Interactive terminal with drag, dock, resize, commands & Windows 11 UX

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -315,3 +315,12 @@
   color: #ffdcd7;
   background-color: #67060c;
 }
+
+/* Terminal scrollbar - hide native, custom scrollbar via React */
+.terminal-scroll {
+  scrollbar-width: none !important;
+}
+
+.terminal-scroll::-webkit-scrollbar {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
Full-featured interactive terminal component on the hero section with real Discord data, 
draggable/resizable window management, dock system, and Windows 11-inspired UX.

## Terminal Commands
| Command | Description |
|---------|-------------|
| `/help` | Show all available commands |
| `/about` | Learn about coding.global |
| `/stats` | Live community stats (members, online, messages, voice hours) |
| `/members` | Member join statistics with weekly/monthly trends |
| `/top` | Top 5 contributors by XP with live data from API |
| `/search <name>` | Search users by name |
| `/discord` | Get Discord invite link |
| `/login` | Login with Discord (OAuth) |
| `/me` | Show logged-in user profile |
| `/clear` | Clear terminal |
| `/usercount` | Quick member + online count |

- Tab autocomplete for all commands
- Command history with arrow keys (↑/↓)
- Animated loading dots (`...`) for async commands
- CMD-style error for unknown commands

## Window Management
- **Drag** — Grab header to freely move terminal anywhere on screen
- **Resize** — All 8 edges/corners (top, bottom, left, right + corners)
- **Minimize** — Collapses to header-only (44px), stays minimized until toggled
- **Maximize** — Full viewport (over navbar, z-index 9999)
- **Double-click header** — Toggle fullscreen on/off
- **X button** — Flies back to dock, restores pre-fullscreen size
- **Viewport clamping** — Can't drag terminal off-screen

## Dock System
- Dock zone in hero section with proximity detection (200px radius)
- Drag near dock → instant snap back (no animation)
- Minimized terminals dock with correct header-only height
- Resize while docked works without accidentally undocking

## Edge Snap (Windows 11 Style)
- Drag to top edge (≤10px) → translucent blue fullscreen preview overlay
- Release → snaps to fullscreen
- "Release for fullscreen" hint text

## Custom Scrollbar
- Native scrollbar hidden via CSS
- React-rendered scrollbar thumb (3px → 8px on hover)
- Click track to jump, drag thumb to scroll
- Smart auto-scroll (only when user is near bottom)
- `overscroll-behavior: contain` prevents page scroll bleed

## Visual Design
- Windows 11 Terminal-style header with minimize/maximize/close buttons
- `>_` terminal icon with "Terminal" label
- Prompt: `coding.global\guest>` (white/red/blue colored)
- Colored output via `{{color:text}}` markup system
- Compact layout (text-sm, tight spacing)
- Staggered hero title animation

## Data Sources
- Discord widget API (member count, online count)
- Bot API: `/top` contributors, `/members` stats, `/search` users
- Auth session for `/me` and `/login`

## Files Changed
- [src/components/pages/home/hero-section.tsx](cci:7://file:///c:/project/Don/coding.global-web/src/components/pages/home/hero-section.tsx:0:0-0:0) — Terminal component (1165 lines)
- [src/app/globals.css](cci:7://file:///c:/project/Don/coding.global-web/src/app/globals.css:0:0-0:0) — Custom scrollbar styles
